### PR TITLE
Add .env with url definitions to repo

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+BACKEND_URL='https://three07-mydiary-nibble.onrender.com'
+FRONTEND_URL='https://scribbleandnibble.vercel.app'


### PR DESCRIPTION
# New Changes

With pull request #67, we need to have a .env in the repo that includes the frontend and backend routes for our app to work. This .env will not hold any secrets.

### .env contents

```
BACKEND_URL='https://three07-mydiary-nibble.onrender.com'
FRONTEND_URL='https://scribbleandnibble.vercel.app'
```